### PR TITLE
Fix to scroll horizontally so that the 4th language is viewable.

### DIFF
--- a/css/lfetheme.css
+++ b/css/lfetheme.css
@@ -576,6 +576,10 @@ a img {
   position: relative;
 }
 
+.full-width-divider.page {
+  overflow-x: auto;
+}
+
 .highlight-module {
   list-style-type: none;
   display: table-cell;
@@ -1128,7 +1132,7 @@ pre code {
   text-shadow: 0px 1px 0px #000;
   margin: 0;
   padding: 0;
-  
+
 }
 
 ul + pre {


### PR DESCRIPTION
In the current site [https://lfex.github.io/hyperpolyglot/](https://lfex.github.io/hyperpolyglot/), horizontal scroll is broken, so the Clojure tab is not visible at all (Latest Chrome browser on Mac)

This fix would allow a horizontal scroll on the table without making the site ugly. Consider this as a minor fix before the redesign.
